### PR TITLE
[TIMOB-18341] Fix malformed Content-Type error with modsecurity

### DIFF
--- a/APSHTTPClient/APSHTTPPostForm.m
+++ b/APSHTTPClient/APSHTTPPostForm.m
@@ -62,7 +62,7 @@
 	NSString *charset = (NSString *)CFStringConvertEncodingToIANACharSetName(CFStringConvertNSStringEncodingToEncoding(NSUTF8StringEncoding));
 
     NSString* boundry = [NSString stringWithFormat:@"0xTibOuNdArY_%i", (int)[[NSDate date] timeIntervalSince1970]];
-    [self addHeaderKey:@"Content-Type" andHeaderValue:[NSString stringWithFormat:@"multipart/form-data; charset=%@; boundary=%@", charset, boundry]];
+    [self addHeaderKey:@"Content-Type" andHeaderValue:[NSString stringWithFormat:@"multipart/form-data; boundary=%@", boundry]];
     
     [self appendStringData:[NSString stringWithFormat:@"--%@\r\n",boundry]];
     
@@ -77,6 +77,7 @@
         }
 
         NSString *key = [allKeys objectAtIndex:i];
+        [self appendStringData: [NSString stringWithFormat:@"Content-Type: charset=\"%@\"\r\n", charset]];
         [self appendStringData: [NSString stringWithFormat:@"Content-Disposition: form-data; name=\"%@\"\r\n", key]];
         [self appendStringData:@"\r\n"];
         [self appendStringData:[NSString stringWithFormat:@"%@\r\n", [[self requestFormDictionay] valueForKey:key]]];


### PR DESCRIPTION
While working on a Titanium iOS application (SDK 3.4.0.GA which uses APSHTTPClient under the hood), I couldn't upload a picture to our backend which uses [modsecurity](https://github.com/SpiderLabs/ModSecurity). The upload request was rejected by modsecurity and the following error appeared in the logs:

`Multipart parsing error (init): Multipart: Invalid boundary in C-T (malformed).`

I looked into APSHTTPClient and saw that the header was created as follow: 
```objective-c 
[self addHeaderKey:@"Content-Type" andHeaderValue:[NSString stringWithFormat:@"multipart/form-data; charset=%@; boundary=%@", charset, boundry]];
```

http://www.w3.org/Protocols/rfc1341/7_2_Multipart.html gives a simple multi-part example: 
```
     From: Nathaniel Borenstein <nsb@bellcore.com> 
     To:  Ned Freed <ned@innosoft.com> 
     Subject: Sample message 
     MIME-Version: 1.0 
     Content-type: multipart/mixed; boundary="simple
     boundary"

     This is the preamble.  It is to be ignored, though it 
     is a handy place for mail composers to include an 
     explanatory note to non-MIME compliant readers. 
     --simple boundary 

     This is implicitly typed plain ASCII text. 
     It does NOT end with a linebreak. 
     --simple boundary 
     Content-type: text/plain; charset=us-ascii

     This is explicitly typed plain ASCII text. 
     It DOES end with a linebreak. 

     --simple boundary-- 
     This is the epilogue.  It is also to be ignored.
```

The reason modsecurity rejected the request is because the Content-Type multipart/data format requires a parameter `boundary` immediately after the subtype. It doesn't expect anything other than the boundary header (except space and ;).

It must be `Content-Type: multipart/form-data; boundary=0xTibOuNdArY_1234567890` in order to work with modsecurity.

The `charset` part has been moved inside each part block.