### PR TITLE
[TIMOB-20048] iOS: Revert APSHTTPClient library to use back NSURLConnection

### DIFF
--- a/APSHTTPClient/APSHTTPRequest.m
+++ b/APSHTTPClient/APSHTTPRequest.m
@@ -6,7 +6,7 @@
  */
 
 #import "APSHTTPClient.h"
-
+#define USE_NSURLSESSION NO
 
 typedef NS_ENUM(NSInteger, APSHTTPCallbackState) {
     APSHTTPCallbackStateReadyState = 0,
@@ -645,6 +645,6 @@ typedef NS_ENUM(NSInteger, APSHTTPCallbackState) {
 }
 -(BOOL)isIOS7OrGreater
 {
-    return [NSURLSession instancesRespondToSelector:@selector(invalidateAndCancel)];
+    return [NSURLSession instancesRespondToSelector:@selector(invalidateAndCancel)] && USE_NSURLSESSION;
 }
 @end

--- a/changelog.md
+++ b/changelog.md
@@ -41,3 +41,7 @@
 ### Version 1.9 ###
 
 * [TIMOB-19609] - Remove "pcm missing" warnings
+
+### Version 1.10 ###
+
+* [TIMOB-20048] - Revert to nsurlconnection


### PR DESCRIPTION
JIRA: https://jira.appcelerator.org/browse/TIMOB-20048