### PR TITLE
fix(ios): explicitly invalidate session after completion

### DIFF
--- a/APSHTTPClient/APSHTTPRequest.m
+++ b/APSHTTPClient/APSHTTPRequest.m
@@ -421,7 +421,7 @@ typedef NS_ENUM(NSInteger, APSHTTPCallbackState) {
   
   [[self postForm] destroyTemporaryData];
   
-  [self.session invalidateAndCancel];
+  [self.session finishTasksAndInvalidate];
 }
 
 - (void)URLSession:(nonnull NSURLSession *)session task:(nonnull NSURLSessionTask *)task didCompleteWithError:(nullable NSError *)error

--- a/APSHTTPClient/APSHTTPRequest.m
+++ b/APSHTTPClient/APSHTTPRequest.m
@@ -420,6 +420,8 @@ typedef NS_ENUM(NSInteger, APSHTTPCallbackState) {
   [self invokeCallbackWithState:APSHTTPCallbackStateLoad];
   
   [[self postForm] destroyTemporaryData];
+  
+  [self.session invalidateAndCancel];
 }
 
 - (void)URLSession:(nonnull NSURLSession *)session task:(nonnull NSURLSessionTask *)task didCompleteWithError:(nullable NSError *)error
@@ -447,6 +449,12 @@ typedef NS_ENUM(NSInteger, APSHTTPCallbackState) {
 - (void)URLSession:(nonnull NSURLSession *)session didBecomeInvalidWithError:(nullable NSError *)error
 {
   DebugLog(@"%s", __PRETTY_FUNCTION__);
+  
+  if (error == nil) {
+    // Ignore explicit session invalidations
+    return;
+  }
+  
   self.response.readyState = APSHTTPResponseStateDone;
   [self invokeCallbackWithState:APSHTTPCallbackStateReadyState];
 

--- a/APSHTTPClient/APSHTTPRequest.m
+++ b/APSHTTPClient/APSHTTPRequest.m
@@ -418,9 +418,9 @@ typedef NS_ENUM(NSInteger, APSHTTPCallbackState) {
   [self invokeCallbackWithState:APSHTTPCallbackStateDataStream];
 
   [self invokeCallbackWithState:APSHTTPCallbackStateLoad];
-  
+
   [[self postForm] destroyTemporaryData];
-  
+
   [self.session finishTasksAndInvalidate];
 }
 
@@ -435,6 +435,7 @@ typedef NS_ENUM(NSInteger, APSHTTPCallbackState) {
     self.response.error = error;
     [self invokeCallbackWithState:APSHTTPCallbackStateError];
     [[self postForm] destroyTemporaryData];
+    [self.session finishTasksAndInvalidate];
     return;
   }
   DebugLog(@"%s", __PRETTY_FUNCTION__);
@@ -449,12 +450,12 @@ typedef NS_ENUM(NSInteger, APSHTTPCallbackState) {
 - (void)URLSession:(nonnull NSURLSession *)session didBecomeInvalidWithError:(nullable NSError *)error
 {
   DebugLog(@"%s", __PRETTY_FUNCTION__);
-  
+
   if (error == nil) {
     // Ignore explicit session invalidations
     return;
   }
-  
+
   self.response.readyState = APSHTTPResponseStateDone;
   [self invokeCallbackWithState:APSHTTPCallbackStateReadyState];
 


### PR DESCRIPTION
JIRA: https://jira.appcelerator.org/browse/TIMOB-26811

According to the docs for the [delegate](https://developer.apple.com/documentation/foundation/nsurlsession/1411530-delegate?language=objc) property, it holds a strong reference to the object. This creates a retain circle since we set the delegate to the request itself so neither the session nor the request will be properly released, creating a memory leak.